### PR TITLE
Add auth header with client id/secret to token requests

### DIFF
--- a/gbdx_auth/gbdx_auth.py
+++ b/gbdx_auth/gbdx_auth.py
@@ -4,6 +4,7 @@ standard_library.install_aliases()
 import os
 import base64
 import json
+from requests.auth import HTTPBasicAuth
 from configparser import ConfigParser
 from datetime import datetime
 
@@ -52,7 +53,8 @@ def session_from_kwargs(**kwargs):
                   username=kwargs.get('username'),
                   password=kwargs.get('password'),
                   client_id=kwargs.get('client_id'),
-                  client_secret=kwargs.get('client_secret'))
+                  client_secret=kwargs.get('client_secret'),
+                  auth=HTTPBasicAuth(kwargs.get('client_id'), kwargs.get('client_secret')))
     return s
 
 
@@ -106,7 +108,8 @@ def session_from_config(config_file):
                               username=cfg.get('gbdx','user_name'),
                               password=cfg.get('gbdx','user_password'),
                               client_id=client_id,
-                              client_secret=client_secret)
+                              client_secret=client_secret,
+                              auth=HTTPBasicAuth(client_id, client_secret))
         save_token(token)
 
     return s


### PR DESCRIPTION
It looks like the oauth requests library uses the provided username and password by default if an 'auth' parameter is not specified.  This change adds an HTTPBasicAuth param, set with the client ID and secret which the GBDX OAuth2 token endpoint expects when requesting a token.